### PR TITLE
docs: typo in examples page

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -65,8 +65,8 @@
     </div>
     <canvas id="render"></canvas>
     <div id="info">
-        <a href="https://github.com/kevglass/propel-js">Git Hub</a> |
-        <a href="https://developers.dusk.gg">Dusk Compatible</a> |
+        <a href="https://github.com/kevglass/propel-js">GitHub</a> |
+        <a href="https://developers.dusk.gg">Dusk-Compatible</a> |
         <a href="https://x.com/cokeandcode">Contact</a>
     </div>
 


### PR DESCRIPTION
Fixes two minor typos, which also makes it clearer that "Dusk-Compatible" is one clickable text instead of two :)