### PR TITLE
reproduction: Change order of body creation in car interactive

### DIFF
--- a/examples/examples-dist/examples/CarInteractive.js
+++ b/examples/examples-dist/examples/CarInteractive.js
@@ -23,10 +23,6 @@ export function carInteractiveInit() {
         physics.addBody(world, rect);
         physics.rotateBody(rect, i % 2 === 0 ? 0.2 : -0.2);
     }
-    circle1 = physics.createCircle(world, { x: 150, y: 0 }, 15, 3, friction, 0);
-    physics.addBody(world, circle1);
-    circle2 = physics.createCircle(world, { x: 190, y: 0 }, 15, 3, friction, 0);
-    physics.addBody(world, circle2);
     const leftAnchor = physics.createCircleShape(world, { x: 150, y: 0 }, 3);
     const rightAnchor = physics.createCircleShape(world, { x: 190, y: 0 }, 3);
     // give them a bit of padding to consume the resolution of wheels against floor
@@ -35,6 +31,10 @@ export function carInteractiveInit() {
     const base = physics.createRectangleShape(world, { x: 170, y: -25 }, 60, 20, 0);
     chassis = physics.createRigidBody(world, { x: 170, y: 10 }, 1, friction, 0, [base, leftAnchor, rightAnchor, leftSensor, rightSensor]);
     physics.addBody(world, chassis);
+    circle1 = physics.createCircle(world, { x: 150, y: 0 }, 15, 3, friction, 0);
+    physics.addBody(world, circle1);
+    circle2 = physics.createCircle(world, { x: 190, y: 0 }, 15, 3, friction, 0);
+    physics.addBody(world, circle2);
     physics.excludeCollisions(world, chassis, circle1);
     physics.excludeCollisions(world, chassis, circle2);
     physics.createJoint(world, circle1, leftSensor, 1, 0);

--- a/examples/examples-dist/examples/Marble.js
+++ b/examples/examples-dist/examples/Marble.js
@@ -1,0 +1,26 @@
+import { physics } from "../../../dist/index.js";
+// simple shapes
+export function marbleInit() {
+    const world = physics.createWorld();
+    world.damp = 0.99;
+    world.angularDamp = 0.95;
+    const slope1 = physics.createRectangle(world, { x: 200, y: 200 }, 200, 10, 0, 0.3, 0.3);
+    physics.rotateBody(slope1, Math.PI / 6);
+    physics.addBody(world, slope1);
+    const slope2 = physics.createRectangle(world, { x: 400, y: 300 }, 200, 10, 0, 0.3, 0.3);
+    physics.rotateBody(slope2, -Math.PI / 6);
+    physics.addBody(world, slope2);
+    const wheelWing1 = physics.createRectangleShape(world, { x: 200, y: 400 }, 10, 100);
+    const wheelWing2 = physics.createRectangleShape(world, { x: 200, y: 400 }, 10, 100, Math.PI / 2);
+    const wheel = physics.createRigidBody(world, { x: 200, y: 400 }, 1, 0.3, 0.3, [wheelWing1, wheelWing2]);
+    physics.addBody(world, wheel);
+    const wheelJoint = physics.createCircle(world, { x: 200, y: 400 }, 10, 0, 0.3, 0.3, false);
+    physics.addBody(world, wheelJoint);
+    physics.excludeCollisions(world, wheel, wheelJoint);
+    physics.createJoint(world, wheel, wheelJoint, 0, 0);
+    const marble1 = physics.createCircle(world, { x: 225, y: -100 }, 20, 2, 0.3, 0.3);
+    physics.addBody(world, marble1);
+    const marble2 = physics.createCircle(world, { x: 275, y: -200 }, 20, 2, 0.3, 0.3);
+    physics.addBody(world, marble2);
+    return world;
+}

--- a/examples/examples-dist/examples/Marble.js
+++ b/examples/examples-dist/examples/Marble.js
@@ -4,6 +4,10 @@ export function marbleInit() {
     const world = physics.createWorld();
     world.damp = 0.99;
     world.angularDamp = 0.95;
+    const marble1 = physics.createCircle(world, { x: 225, y: -100 }, 20, 2, 0.3, 0.3);
+    physics.addBody(world, marble1);
+    const marble2 = physics.createCircle(world, { x: 275, y: -200 }, 20, 2, 0.3, 0.3);
+    physics.addBody(world, marble2);
     const slope1 = physics.createRectangle(world, { x: 200, y: 200 }, 200, 10, 0, 0.3, 0.3);
     physics.rotateBody(slope1, Math.PI / 6);
     physics.addBody(world, slope1);
@@ -18,9 +22,5 @@ export function marbleInit() {
     physics.addBody(world, wheelJoint);
     physics.excludeCollisions(world, wheel, wheelJoint);
     physics.createJoint(world, wheel, wheelJoint, 0, 0);
-    const marble1 = physics.createCircle(world, { x: 225, y: -100 }, 20, 2, 0.3, 0.3);
-    physics.addBody(world, marble1);
-    const marble2 = physics.createCircle(world, { x: 275, y: -200 }, 20, 2, 0.3, 0.3);
-    physics.addBody(world, marble2);
     return world;
 }

--- a/examples/examples-dist/index.js
+++ b/examples/examples-dist/index.js
@@ -16,6 +16,7 @@ import { noGravityInit } from "./examples/NoGravity.js";
 import { car3Init } from "./examples/Car3.js";
 import { car4Init, car4Update } from "./examples/Car4.js";
 import { carInteractiveInit, carInteractiveInput, carInteractiveUpdate } from "./examples/CarInteractive.js";
+import { marbleInit } from "./examples/Marble.js";
 const canvas = document.getElementById("render");
 const ctx = canvas.getContext("2d");
 canvas.width = 500;
@@ -149,6 +150,7 @@ const DEMOS = [
     { name: "Car Flat", init: car3Init },
     { name: "Car Road", init: car4Init, update: car4Update },
     { name: "Car Interactive", init: carInteractiveInit, input: carInteractiveInput, update: carInteractiveUpdate },
+    { name: "Marble", init: marbleInit },
 ];
 const demoList = document.getElementById("demo");
 for (const demo of DEMOS) {

--- a/examples/src/examples/CarInteractive.ts
+++ b/examples/src/examples/CarInteractive.ts
@@ -30,11 +30,6 @@ export function carInteractiveInit() {
 
         physics.rotateBody(rect, i % 2 === 0 ? 0.2 : -0.2 )
     }
-    circle1 = physics.createCircle(world, { x: 150, y: 0 }, 15, 3, friction, 0) as physics.DynamicRigidBody;
-    physics.addBody(world, circle1);
-    circle2 = physics.createCircle(world, { x: 190, y: 0 }, 15, 3, friction, 0) as physics.DynamicRigidBody;
-    physics.addBody(world, circle2);
-
     const leftAnchor = physics.createCircleShape(world, { x: 150, y: 0 }, 3);
     const rightAnchor = physics.createCircleShape(world, { x: 190, y: 0 }, 3);
 
@@ -45,6 +40,12 @@ export function carInteractiveInit() {
     const base = physics.createRectangleShape(world, { x: 170, y: -25 }, 60, 20, 0);
     chassis = physics.createRigidBody(world, { x: 170, y: 10 }, 1, friction, 0, [base, leftAnchor, rightAnchor,leftSensor, rightSensor]) as physics.DynamicRigidBody
     physics.addBody(world, chassis);
+
+    circle1 = physics.createCircle(world, { x: 150, y: 0 }, 15, 3, friction, 0) as physics.DynamicRigidBody;
+    physics.addBody(world, circle1);
+    circle2 = physics.createCircle(world, { x: 190, y: 0 }, 15, 3, friction, 0) as physics.DynamicRigidBody;
+    physics.addBody(world, circle2);
+
     physics.excludeCollisions(world, chassis, circle1);
     physics.excludeCollisions(world, chassis, circle2);
     physics.createJoint(world, circle1, leftSensor, 1, 0);

--- a/examples/src/examples/Marble.ts
+++ b/examples/src/examples/Marble.ts
@@ -6,6 +6,12 @@ export function marbleInit(): physics.World {
     world.damp = 0.99;
     world.angularDamp = 0.95;
 
+    const marble1 = physics.createCircle(world, { x: 225, y: -100 }, 20, 2, 0.3, 0.3);
+    physics.addBody(world, marble1);
+
+    const marble2 = physics.createCircle(world, { x: 275, y: -200 }, 20, 2, 0.3, 0.3);
+    physics.addBody(world, marble2);
+
     const slope1 = physics.createRectangle(world, { x: 200, y: 200 }, 200, 10, 0, 0.3, 0.3);
     physics.rotateBody(slope1, Math.PI / 6);
     physics.addBody(world, slope1);
@@ -23,12 +29,6 @@ export function marbleInit(): physics.World {
     physics.addBody(world, wheelJoint);
     physics.excludeCollisions(world, wheel, wheelJoint);
     physics.createJoint(world, wheel, wheelJoint, 0, 0);
-
-    const marble1 = physics.createCircle(world, { x: 225, y: -100 }, 20, 2, 0.3, 0.3);
-    physics.addBody(world, marble1);
-
-    const marble2 = physics.createCircle(world, { x: 275, y: -200 }, 20, 2, 0.3, 0.3);
-    physics.addBody(world, marble2);
 
     return world;
 }

--- a/examples/src/examples/Marble.ts
+++ b/examples/src/examples/Marble.ts
@@ -1,0 +1,34 @@
+import { physics } from "../../../dist/index.js";
+
+// simple shapes
+export function marbleInit(): physics.World {
+    const world = physics.createWorld();
+    world.damp = 0.99;
+    world.angularDamp = 0.95;
+
+    const slope1 = physics.createRectangle(world, { x: 200, y: 200 }, 200, 10, 0, 0.3, 0.3);
+    physics.rotateBody(slope1, Math.PI / 6);
+    physics.addBody(world, slope1);
+
+    const slope2 = physics.createRectangle(world, { x: 400, y: 300 }, 200, 10, 0, 0.3, 0.3);
+    physics.rotateBody(slope2, -Math.PI / 6);
+    physics.addBody(world, slope2);
+
+    const wheelWing1 = physics.createRectangleShape(world, { x: 200, y: 400 }, 10, 100);
+    const wheelWing2 = physics.createRectangleShape(world, { x: 200, y: 400 }, 10, 100, Math.PI / 2);
+    const wheel = physics.createRigidBody(world, { x: 200, y: 400 }, 1, 0.3, 0.3, [wheelWing1, wheelWing2]);
+    physics.addBody(world, wheel);
+
+    const wheelJoint = physics.createCircle(world, { x: 200, y: 400 }, 10, 0, 0.3, 0.3, false);
+    physics.addBody(world, wheelJoint);
+    physics.excludeCollisions(world, wheel, wheelJoint);
+    physics.createJoint(world, wheel, wheelJoint, 0, 0);
+
+    const marble1 = physics.createCircle(world, { x: 225, y: -100 }, 20, 2, 0.3, 0.3);
+    physics.addBody(world, marble1);
+
+    const marble2 = physics.createCircle(world, { x: 275, y: -200 }, 20, 2, 0.3, 0.3);
+    physics.addBody(world, marble2);
+
+    return world;
+}

--- a/examples/src/index.ts
+++ b/examples/src/index.ts
@@ -17,6 +17,7 @@ import { noGravityInit } from "./examples/NoGravity.js";
 import { car3Init } from "./examples/Car3.js";
 import { car4Init, car4Update } from "./examples/Car4.js";
 import { carInteractiveInit, carInteractiveInput, carInteractiveUpdate } from "./examples/CarInteractive.js";
+import { marbleInit } from "./examples/Marble.js";
 
 const canvas = document.getElementById("render") as HTMLCanvasElement;
 const ctx = canvas.getContext("2d") as CanvasRenderingContext2D;
@@ -185,6 +186,7 @@ const DEMOS: Demo[] = [
     { name: "Car Flat", init: car3Init },
     { name: "Car Road", init: car4Init, update: car4Update},
     { name: "Car Interactive", init: carInteractiveInit, input: carInteractiveInput, update: carInteractiveUpdate },
+    { name: "Marble", init: marbleInit },
 ];
 
 const demoList = document.getElementById("demo");


### PR DESCRIPTION
_This is not a request to merge the code, but to show the reproduction of (maybe) an issue_

When changing the order of the body creation, the system behaves differently. In this case, the car moves much slower / feels "heavier" when the wheels are created after the chassis. I am not sure if this is intended behavior or not.