### PR TITLE
Add reference to colliding shapes to a sensor

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -27,6 +27,8 @@ export declare namespace physics {
         sensor: boolean;
         /** True if this sensor is currently triggered */
         sensorColliding: boolean;
+        /** The IDs of the shapes that are colliding with this sensor */
+        sensorCollisions: number[];
         /** The inertia applied when this shape is colliding */
         inertia: number;
         /** The ID of the body this shape is part of */

--- a/dist/index.js
+++ b/dist/index.js
@@ -382,6 +382,7 @@ export var physics;
                     return;
                 }
                 s.sensorColliding = false;
+                s.sensorCollisions = [];
             });
         }
         for (const body of dynamics) {
@@ -462,10 +463,16 @@ export var physics;
                         if (testCollision(world, bodyI, bodyJ, collisionInfo)) {
                             if (collisionInfo.shapeA && collisionInfo.shapeA.sensor) {
                                 collisionInfo.shapeA.sensorColliding = true;
+                                if (collisionInfo.shapeB) {
+                                    collisionInfo.shapeA.sensorCollisions.push(collisionInfo.shapeB.id);
+                                }
                                 continue;
                             }
                             if (collisionInfo.shapeB && collisionInfo.shapeB.sensor) {
                                 collisionInfo.shapeB.sensorColliding = true;
+                                if (collisionInfo.shapeA) {
+                                    collisionInfo.shapeB.sensorCollisions.push(collisionInfo.shapeA.id);
+                                }
                                 continue;
                             }
                             if (bodyJ.permeability > 0) {
@@ -689,10 +696,12 @@ export var physics;
         }
         if (A.sensor) {
             A.sensorColliding = true;
+            A.sensorCollisions.push(B.id);
             return;
         }
         if (B.sensor) {
             B.sensorColliding = true;
+            B.sensorCollisions.push(A.id);
             return;
         }
         collision.depth = D; // depth
@@ -722,6 +731,7 @@ export var physics;
             boundingBox: calcBoundingBox(ShapeType.CIRCLE, radius, [], center),
             sensor,
             sensorColliding: false,
+            sensorCollisions: [],
             inertia: 0
         };
     }
@@ -753,6 +763,7 @@ export var physics;
             boundingBox: calcBoundingBox(ShapeType.RECTANGLE, bounds, vertices, center),
             sensor,
             sensorColliding: false,
+            sensorCollisions: [],
             inertia: 0,
             angle: ang
         };

--- a/examples/examples-dist/examples/Teleporter.js
+++ b/examples/examples-dist/examples/Teleporter.js
@@ -1,0 +1,56 @@
+import { physics } from "../../../dist/index.js";
+let frameCount = 0;
+let teleporter;
+let teleporterSpawn;
+export function teleporterInit() {
+    const world = physics.createWorld();
+    world.restTime = 1000;
+    // teleporter
+    teleporter = physics.createRectangle(world, { x: 140, y: 450 }, 180, 30, 0, 0.5, 0.5, true);
+    physics.addBody(world, teleporter);
+    // ground
+    const rect = physics.createRectangle(world, { x: 360, y: 450 }, 180, 30, 0, 0.5, 0.5);
+    physics.addBody(world, rect);
+    // this is not really needed as a physical object, it's just here to reference its position
+    teleporterSpawn = physics.createRectangle(world, { x: 360, y: 150 }, 50, 50, 0, 0.5, 0.5);
+    physics.addBody(world, teleporterSpawn);
+    return world;
+}
+export function teleporterUpdate(world) {
+    // spawn a new body every second
+    if (frameCount % 60 === 0) {
+        const spawnPosition = { x: 50 + Math.floor(Math.random() * 180), y: 0 };
+        let body;
+        if (Math.random() < 0.5) {
+            body = physics.createCircle(world, spawnPosition, 20 + (Math.random() * 20), 1, 0.5, 1, false, { debug: 'circle' });
+        }
+        else {
+            body = physics.createRectangle(world, spawnPosition, 20 + (Math.random() * 20), 20 + (Math.random() * 20), 1, 0.5, 1, false, { debug: 'rectangle' });
+        }
+        physics.setRotation(body, Math.random() * Math.PI * 2);
+        physics.excludeCollisions(world, body, teleporterSpawn);
+        physics.addBody(world, body);
+    }
+    // teleport bodies that touch the teleporter
+    for (const teleporterShape of teleporter.shapes.filter(shape => shape.sensor)) {
+        for (const collidingShapeId of teleporterShape.sensorCollisions) {
+            const collidingBody = world.dynamicBodies.find(body => body.shapes.some(s => s.id === collidingShapeId));
+            if (collidingBody) {
+                // teleport the body to the spawn position
+                physics.setCenter(collidingBody, teleporterSpawn.center);
+                // reset the body's velocity and angular velocity
+                // - or keep their original values for maximum chaos :-)
+                collidingBody.velocity = { x: 0, y: 0 };
+                collidingBody.angularVelocity = 0;
+            }
+        }
+    }
+    // remove bodies that fell off the screen
+    for (const body of world.dynamicBodies) {
+        if (body.center.y > 600) {
+            physics.removeBody(world, body);
+        }
+    }
+    frameCount++;
+    return;
+}

--- a/examples/examples-dist/index.js
+++ b/examples/examples-dist/index.js
@@ -17,6 +17,7 @@ import { car3Init } from "./examples/Car3.js";
 import { car4Init, car4Update } from "./examples/Car4.js";
 import { carInteractiveInit, carInteractiveInput, carInteractiveUpdate } from "./examples/CarInteractive.js";
 import { marbleInit } from "./examples/Marble.js";
+import { teleporterInit, teleporterUpdate } from "./examples/Teleporter.js";
 const canvas = document.getElementById("render");
 const ctx = canvas.getContext("2d");
 canvas.width = 500;
@@ -141,6 +142,7 @@ const DEMOS = [
     { name: "Upset Avians", init: avianInit },
     { name: "Platformer", init: platformerInit, input: platformerInput, update: platformerUpdate },
     { name: "Sensor", init: sensorInit },
+    { name: "Teleporter", init: teleporterInit, update: teleporterUpdate },
     { name: "Compound", init: compoundInit },
     { name: "Polybox", init: polyboxInit },
     { name: "Exclusions", init: exclusionsInit },

--- a/examples/src/examples/Teleporter.ts
+++ b/examples/src/examples/Teleporter.ts
@@ -1,0 +1,66 @@
+import { physics } from "../../../dist/index.js";
+
+let frameCount = 0;
+let teleporter: physics.Body;
+let teleporterSpawn: physics.Body;
+
+export function teleporterInit(): physics.World {
+    const world = physics.createWorld();
+    world.restTime = 1000;
+
+    // teleporter
+    teleporter = physics.createRectangle(world, { x: 140, y: 450 }, 180, 30, 0, 0.5, 0.5, true);
+    physics.addBody(world, teleporter);
+
+    // ground
+    const rect = physics.createRectangle(world, { x: 360, y: 450 }, 180, 30, 0, 0.5, 0.5);
+    physics.addBody(world, rect);
+
+    // this is not really needed as a physical object, it's just here to reference its position
+    teleporterSpawn = physics.createRectangle(world, { x: 360, y: 150 }, 50, 50, 0, 0.5, 0.5);
+    physics.addBody(world, teleporterSpawn);
+
+    return world;
+}
+
+export function teleporterUpdate(world: physics.World): physics.Body | undefined {
+    // spawn a new body every second
+    if (frameCount % 60 === 0) {
+        const spawnPosition = { x: 50 + Math.floor(Math.random() * 180), y: 0 };
+        let body: physics.Body;
+        if (Math.random() < 0.5) {
+            body = physics.createCircle(world, spawnPosition, 20 + (Math.random() * 20), 1, 0.5, 1, false, { debug: 'circle' });
+        } else {
+            body = physics.createRectangle(world, spawnPosition, 20 + (Math.random() * 20), 20 + (Math.random() * 20), 1, 0.5, 1, false, { debug: 'rectangle' });
+        }
+        physics.setRotation(body as physics.DynamicRigidBody, Math.random() * Math.PI * 2);
+        physics.excludeCollisions(world, body, teleporterSpawn);
+        physics.addBody(world, body);
+    }
+
+    // teleport bodies that touch the teleporter
+    for (const teleporterShape of teleporter.shapes.filter(shape => shape.sensor)) {
+        for (const collidingShapeId of teleporterShape.sensorCollisions) {
+            const collidingBody = world.dynamicBodies.find(body => body.shapes.some(s => s.id === collidingShapeId));
+            if (collidingBody) {
+                // teleport the body to the spawn position
+                physics.setCenter(collidingBody, teleporterSpawn.center);
+
+                // reset the body's velocity and angular velocity
+                // - or keep their original values for maximum chaos :-)
+                collidingBody.velocity = { x: 0, y: 0 };
+                collidingBody.angularVelocity = 0;
+            }
+        }
+    }
+
+    // remove bodies that fell off the screen
+    for (const body of world.dynamicBodies) {
+        if (body.center.y > 600) {
+            physics.removeBody(world, body);
+        }
+    }
+    frameCount++;
+
+    return;
+}

--- a/examples/src/index.ts
+++ b/examples/src/index.ts
@@ -18,6 +18,7 @@ import { car3Init } from "./examples/Car3.js";
 import { car4Init, car4Update } from "./examples/Car4.js";
 import { carInteractiveInit, carInteractiveInput, carInteractiveUpdate } from "./examples/CarInteractive.js";
 import { marbleInit } from "./examples/Marble.js";
+import { teleporterInit, teleporterUpdate } from "./examples/Teleporter.js";
 
 const canvas = document.getElementById("render") as HTMLCanvasElement;
 const ctx = canvas.getContext("2d") as CanvasRenderingContext2D;
@@ -177,6 +178,7 @@ const DEMOS: Demo[] = [
     { name: "Upset Avians", init: avianInit },
     { name: "Platformer", init: platformerInit, input: platformerInput, update: platformerUpdate },
     { name: "Sensor", init: sensorInit },
+    { name: "Teleporter", init: teleporterInit, update: teleporterUpdate },
     { name: "Compound", init: compoundInit },
     { name: "Polybox", init: polyboxInit },
     { name: "Exclusions", init: exclusionsInit },

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,8 @@ export namespace physics {
         sensor: boolean;
         /** True if this sensor is currently triggered */
         sensorColliding: boolean;
+        /** The IDs of the shapes that are colliding with this sensor */
+        sensorCollisions: number[];
         /** The inertia applied when this shape is colliding */
         inertia: number;
         /** The ID of the body this shape is part of */
@@ -598,6 +600,7 @@ export namespace physics {
                     return;
                 }
                 s.sensorColliding = false;
+                s.sensorCollisions = [];
             });
         }
 
@@ -687,10 +690,16 @@ export namespace physics {
                         if (testCollision(world, bodyI, bodyJ, collisionInfo)) {
                             if (collisionInfo.shapeA && collisionInfo.shapeA.sensor) {
                                 collisionInfo.shapeA.sensorColliding = true;
+                                if (collisionInfo.shapeB) {
+                                    collisionInfo.shapeA.sensorCollisions.push(collisionInfo.shapeB.id);
+                                }
                                 continue;
                             }
                             if (collisionInfo.shapeB && collisionInfo.shapeB.sensor) {
                                 collisionInfo.shapeB.sensorColliding = true;
+                                if (collisionInfo.shapeA) {
+                                    collisionInfo.shapeB.sensorCollisions.push(collisionInfo.shapeA.id);
+                                }
                                 continue;
                             }
 
@@ -927,10 +936,12 @@ export namespace physics {
         }
         if (A.sensor) {
             A.sensorColliding = true;
+            A.sensorCollisions.push(B.id);
             return;
         }
         if (B.sensor) {
             B.sensorColliding = true;
+            B.sensorCollisions.push(A.id);
             return;
         }
 
@@ -964,6 +975,7 @@ export namespace physics {
             boundingBox: calcBoundingBox(ShapeType.CIRCLE, radius, [], center),
             sensor,
             sensorColliding: false,
+            sensorCollisions: [],
             inertia: 0
         }
     }
@@ -998,6 +1010,7 @@ export namespace physics {
             boundingBox: calcBoundingBox(ShapeType.RECTANGLE, bounds, vertices, center),
             sensor,
             sensorColliding: false,
+            sensorCollisions: [],
             inertia: 0,
             angle: ang
         }


### PR DESCRIPTION
### Use case
When having many bodies that collide with the same body, it is often easier to put the sensor onto that one body. This means less bodies to handle and in some cases a more logical approach (a teleporter is the sensor, not the objects touching it).
For this to work the sensor needs to have a reference to the objects colliding with it. So far it only knows _if_ it is colliding with something.

### Remarks
- I used references to shapes and not to bodies to enable more fine grained scenarios, but also because I could not easily get access to the body id at one point
- I left the property `sensorColliding` in for BC, but in theory it is no more needed, as you can always check `sensorCollisions.length > 0` now, if you only want to know if anything is colliding
- I did not add the regenerated docs, because building the docs in my fork creates links to GitHub in my fork with an concrete commit hash
- please feel free to change, adjust or discard the changes as you prefer